### PR TITLE
Use protocol relative link for Font Awesome CSS

### DIFF
--- a/index.php
+++ b/index.php
@@ -146,7 +146,7 @@ header('Content-type: text/html; charset=utf-8');
     <link rel="stylesheet" href='<?php echo $source_url ."/css/normalize.min.css'>"; ?>
     <link rel="stylesheet" href='<?php echo $source_url ."/css/rg2.css'>"; ?>
     <link rel="stylesheet" href="//code.jquery.com/ui/1.11.3/themes/<?php echo $ui_theme; ?>/jquery-ui.min.css">
-    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <!-- ('RG2VERSION', '1.2.5') -->
   </head>
   <body>


### PR DESCRIPTION
This change is required for the CSS file to load when running the site on https.