### PR TITLE
Georeferencing: Display georeferencing information on a map

### DIFF
--- a/css/rg2.css
+++ b/css/rg2.css
@@ -670,3 +670,7 @@ body {
   margin-bottom: 18px;
   margin-right: 5%;
 }
+
+#rg2-world-file-map {
+  height: 180px;
+}

--- a/html/manager.html
+++ b/html/manager.html
@@ -117,6 +117,8 @@
   <div id="rg2-georef-type">
     <span>Co-ords:<select class="pushright manage-event-edit-div" id="rg2-georef-selected"></select></span>
   </div>
+  <div id="rg2-world-file-map" style="display:none;">
+  </div>
   <div id="rg2-world-file">
     <p id="georef-A">A:</p>
     <p id="georef-D">D:</p>

--- a/html/script.html
+++ b/html/script.html
@@ -52,3 +52,10 @@ start_language: '<?php echo $lang; ?>'
 };
 <?php echo '$(document).ready(rg2.init);' ?>
 </script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css"
+   integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
+   crossorigin=""/>
+ <!-- Make sure you put this AFTER Leaflet's CSS -->
+ <script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"
+   integrity="sha512-nMMmRyTVoLYqjP9hrbed9S+FzjZHW5gY1TWCHA5ckwXZBadntCNs8kEqAWdrb9O7rxbCaA4lKTIWjDXZxflOcA=="
+   crossorigin=""></script>

--- a/js/manager.js
+++ b/js/manager.js
@@ -45,6 +45,8 @@
     this.maps = [];
     this.localworldfile = new rg2.Worldfile(0);
     this.worldfile = new rg2.Worldfile(0);
+    this.georefmap = L.map('rg2-world-file-map');
+    this.initialiseMap();
     this.initialiseUI();
   }
 
@@ -71,6 +73,13 @@
         // prevent form submission
         return false;
       });
+    },
+
+    initialiseMap : function () {
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	      maxZoom: 19,
+	      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+      }).addTo(this.georefmap);
     },
 
     logIn : function () {
@@ -1439,10 +1448,12 @@
         delete this.newMap.worldfile;
         this.newMap.worldfile = new rg2.Worldfile(wf);
         this.updateGeorefDisplay();
+        this.updateGeorefMap();
       } catch (err) {
         delete this.newMap.worldfile;
         this.newMap.worldfile = new rg2.Worldfile(0);
         this.updateGeorefDisplay();
+        this.updateGeorefMap();
         return;
       }
     },
@@ -1453,6 +1464,22 @@
       for (i = 0; i < letters.length; i += 1) {
         $("#georef-" + letters[i]).empty().text(letters[i] + ": " + this.newMap.worldfile[letters[i]]);
       }
+    },
+    updateGeorefMap : function () {
+      // Plot a polygon and recentre the map on the polygon
+      lon = this.newMap.lon;
+      lat = this.newMap.lat;
+      poly_coords = [];
+      // For some reason this is the order the coordinates are stored in.
+      indicies = [3, 1, 2, 0]
+      indicies.forEach( function(i) {
+        poly_coords.push([lat[i], lon[i]])
+      })
+      poly = L.polygon(poly_coords, { color: 'red'})
+      poly.addTo(this.georefmap);
+      $("#rg2-world-file-map").show()
+      this.georefmap.invalidateSize();
+      this.georefmap.fitBounds(poly.getBounds());
     }
   };
   rg2.Manager = Manager;


### PR DESCRIPTION
This patch adds a small map to the georeferencing window which shows
the precise extent of the map on OpenStreetMap. This is a sanity check
to make sure the georeferencing information for the map is correct.
There are quite a lot of maps uploaded which have the wrong
georeferencing information or the world file has been given the wrong
CRS.

Another option would be to overlay the actual map image over the OpenStreetMap layer so you could check more precisely that it lined up. 

Note: I didn't know how to regenerate the minified javascript files. In order to develop the patch I had to modify the source to use the unminified versions. How do you usually do this?


Example when using the correct CRS:

![image](https://user-images.githubusercontent.com/1216657/44937832-35304400-ad73-11e8-908e-23181e110c26.png)

Example when using the wrong CRS:

![image](https://user-images.githubusercontent.com/1216657/44937859-4ed18b80-ad73-11e8-9505-46705845f3b6.png)

