### PR TITLE
Result tab accordion header fix

### DIFF
--- a/js/results.js
+++ b/js/results.js
@@ -28,6 +28,9 @@
       }
       // save each result
       for (i = 0; i < l; i += 1) {
+        if (data[i].resultid > rg2.config.GPS_RESULT_OFFSET && data[i].coursename== '' ) {
+          data[i].coursename = rg2.courses.getCourseDetails(data[i].courseid).name;
+        }
         if (isScoreEvent) {
           variant = data[i].variant;
           result = new rg2.Result(data[i], isScoreEvent, codes[variant], scorex[variant], scorey[variant]);


### PR DESCRIPTION
RG1 doesn't write the coursename into kilpailijat_xxx.txt file, when a competitor uploads a GPS track. When the first competitor in the class has GPS track in RG2, the course id appears on Results tab in course accordion header.
This is a hotfix for the issue.