### PR TITLE
Remember scroll bar location when changing tabs

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,0 +1,44 @@
+# Instructions for running RG2 locally (linux)
+
+## Install required packages
+* web server e.g. apache (`sudo apt install apache2`)
+* php (`sudo apt install php libapache2-mod-php`)
+* node.js (`sudo apt install nodejs`)
+* grunt (`npm install -g grunt-cli`)
+
+## Fork and clone repo
+`git clone https://github.com/<your username>/rg2`
+
+## Run grunt
+```bash
+cd rg2
+grunt
+```
+
+## Setup apache web server
+In your `apache2.conf` e.g. `sudo vi /etc/apache2/apache2.conf`
+```
+<Directory /path/to/rg2/>
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Require all granted
+</Directory>
+Alias "/rg2" "/path/to/rg2"
+```
+Then `sudo service apache2 restart`.
+
+## Setup rg2 config options
+Edit `rg2-config.txt` and rename to `rg2-config.php`, suggested options:
+```php
+define('RG_BASE_DIRECTORY', 'http://localhost/');
+define('OVERRIDE_KARTAT_DIRECTORY', 'kartat/');
+```
+Create some test data (from your `rg2` directory)
+```bash
+mkdir kartat
+mkdir kartat/cache
+wget https://www.happyherts.routegadget.co.uk/kartat/cache/events.json -O kartat/cache/events.json
+```
+
+## Launch browser
+Go to `http://localhost/rg2/`, and you should see your local rg2 app.

--- a/js/rg2ui.js
+++ b/js/rg2ui.js
@@ -61,8 +61,7 @@
 
     // called whenever the active tab changes to tidy up as necessary
     tabActivated: function () {
-      var active = $("#rg2-info-panel").tabs("option", "active");
-      switch (active) {
+      switch (this.getActiveTab()) {
         case rg2.config.TAB_DRAW:
           rg2.courses.removeAllFromDisplay();
           rg2.drawing.showCourseInProgress();
@@ -70,6 +69,12 @@
         default:
           break;
       }
+
+      // Set scroll bar position in tab to how it was when 
+      // user was last looking at it
+      var scrollPos = $("#rg2-info-panel").attr(this.getScrollPosAttrName());
+      $("#rg2-event-tab-body").scrollParent().scrollTop(scrollPos);
+
       rg2.redraw(false);
     },
 
@@ -580,9 +585,21 @@
       });
     },
 
+    getScrollPosAttrName: function () {
+      return `scroll-${this.getActiveTab()}`;
+    },
+
+    getActiveTab: function () {
+      return $("#rg2-info-panel").tabs("option", "active");
+    },
+
     setUIEventHandlers: function () {
       var text, newlang, self;
       self = this;
+      $("#rg2-info-panel-tab-body").scroll(function () {
+        // Save current scroll bar position in tab
+        $("#rg2-info-panel").attr(self.getScrollPosAttrName(), $(this).scrollTop());
+      });
       $("#rg2-resize-info").click(function () {
         rg2.resizeInfoDisplay();
       });


### PR DESCRIPTION
The tabs on the left hand side scroll vertically when the contents
is long, e.g. when there are many events.

When switching tabs, e.g. between Events, Courses, or Results,
the position of the scroll bar is reset. E.g. if the user had scrolled down to
the bottom event, clicked on it, then gone back to the events tab,
the scroll bar would be reset to the top of the events list.

With this change, the scroll position is remembered for each tab between
switching by saving the scroll position for each tab as an attribute of
the tab contents div.

Also adding some instructions for installing/running rg2 locally as I couldn't
find any and it might save someone else a bit of googling.