### PR TITLE
Add route to map directly from strava

### DIFF
--- a/app/event.php
+++ b/app/event.php
@@ -36,6 +36,12 @@ class event
             $all['results'] = result::getResultsForEvent($id);
             $all['routes'] = route::getRoutesForEvent($id);
             $all['API version'] = RG2VERSION;
+            if (defined('STRAVA_SECRET')){
+                $all['strava'] = 'true';
+            } else {
+                $all['strava'] = 'false';
+            }
+
             $output = json_encode($all);
             @file_put_contents(CACHE_DIRECTORY."all_".$id.".json", $output);
         }

--- a/app/strava.php
+++ b/app/strava.php
@@ -1,0 +1,84 @@
+<?php
+
+class strava
+{
+
+	public static function getStravaActivities($code)
+	{
+		//request token
+		$token = strava::getToken($code);
+		//decode and get access token		
+		$t = json_decode($token);
+		$access_token = $t->access_token;
+	
+	  // just echo the token, don't get activities
+	  //echo "{\"access_token\":" .$access_token. "}";
+	
+		//get latest strava activities	
+	  $activities = strava::getActivities($access_token);
+	
+	  echo $activities;
+	
+	}
+
+    public static function getToken($code)
+    {
+		$url = 'https://www.strava.com/api/v3/oauth/token';
+		$data = array('client_id' => STRAVA_CLIENT, 'client_secret' => STRAVA_SECRET,
+					   'code' => $code, 'grant_type' => 'authorization_code');
+
+		// use key 'http' even if you send the request to https://...
+		$options = array(
+			'http' => array(
+				'header'  => "Content-type: application/x-www-form-urlencoded\r\n",
+				'method'  => 'POST',
+				'content' => http_build_query($data)
+			)
+		);
+		$context  = stream_context_create($options);
+		$result = file_get_contents($url, false, $context);
+		if ($result === FALSE) { /* Handle error */ }
+		return $result;
+    }
+	
+	public static function getActivities($token)
+    {
+		$url = 'https://www.strava.com/api/v3/athlete/activities';
+
+		// use key 'http' even if you send the request to https://...
+		$options = array(
+			'http' => array(
+				'header'  => "Authorization: Bearer " . $token,
+				'method'  => 'GET'
+			)
+		);
+		$context  = stream_context_create($options);
+		$activities = file_get_contents($url, false, $context);
+		if ($activities === FALSE) { /* Handle error */ };
+	
+		$result = "{\"access_token\":\"" .$token. "\", \"activities\":" .$activities."}";
+
+		return $result;
+    }
+
+	public static function getActivityStream($data){
+
+		list($activity, $token) = explode('|', $data);
+
+		$url = 'https://www.strava.com/api/v3/activities/'. $activity . '/streams?keys=latlng,time';
+
+		// use key 'http' even if you send the request to https://...
+		$options = array(
+			'http' => array(
+				'header'  => "Authorization: Bearer " . $token,
+				'method'  => 'GET'
+			)
+		);
+		$context  = stream_context_create($options);
+		$stream = file_get_contents($url, false, $context);
+		if ($stream === FALSE) { /* Handle error */ };
+
+		return $stream;
+	}
+
+}

--- a/css/rg2.css
+++ b/css/rg2.css
@@ -406,6 +406,54 @@ html, body {
   display: table-cell;
 }
 
+.border{
+  padding: 2px;
+}
+
+.grid-container {
+  border: 1px solid silver;
+  border-radius: 3px;
+  display: grid;
+  grid-template-areas:
+    'top top btn'
+    'left right btn';
+  grid-gap: 1px;
+  background-color: white;
+  padding: 2px;
+}
+
+.grid-container > span {
+  background-color: white;
+  text-align: left;
+  padding: 1px 1px 1px 1px;
+  font-size: 12px;
+}
+
+#act-title{
+  text-align:left;
+  font-weight: bold;
+  grid-area:top;
+}
+
+#act-type{
+  grid-area:left;
+}
+
+#act-date{
+  grid-area:right;
+}
+
+#act-btn{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid darkslategrey;
+  border-radius: 3px;
+  background-color: silver;
+  grid-area:btn;
+}
+
+
 #rg2-manage-edit .ui-button {
 	margin-top: 10px;
   margin-bottom: 10px;

--- a/html/infopanel.html
+++ b/html/infopanel.html
@@ -75,6 +75,10 @@
     <div id="rg2-select-gps-file">
       <input type='file' accept='.gpx, .tcx' id='rg2-load-gps-file'>
     </div>
+    <div id="strava" class="singlerow">
+      <button type="button" id="btn-get-strava">Get 10 most recent activities from Strava</button>  
+      <div id="strava-activities" class="singlerow"></div>
+   </div>
     <div class="singlerow">
       <button class = "singlerowitem" id="btn-autofit-gps">Autofit</button>
       <div id="rg2-offset-spinner" class="singlerowitem">

--- a/js/draw.js
+++ b/js/draw.js
@@ -28,6 +28,10 @@
       this.gpstrack.uploadGPS(evt);
     },
 
+    uploadStrava : function (evt) {
+      this.gpstrack.uploadStrava(evt);
+    },
+
     getControlXY : function () {
       return {x: this.controlx, y: this.controly};
     },
@@ -341,6 +345,7 @@
       $("#btn-three-seconds").button('enable');
       // setting value to null allows you to open the same file again if needed
       $("#rg2-load-gps-file").val(null).button('enable');
+      $("#btn-get-strava").button('enable');
       rg2.redraw(false);
     },
 

--- a/js/gpstrack.js
+++ b/js/gpstrack.js
@@ -119,6 +119,31 @@
         }
       }
     },
+  
+    uploadStrava : function(json){
+      for (i=0; i < json.data.length; i++){
+
+        const d = json.data[i];
+
+        if (d.type === 'latlng'){
+
+          for (l=0; l < d.data.length; l++){
+            const lat = d.data[l][0];
+            const lon = d.data[l][1];
+            this.lat.push(lat);
+            this.lon.push(lon);
+          };
+
+        } else if (d.type === 'time'){
+            
+          for (t=0; t < d.data.length; t++){
+            const tm = d.data[t]
+            this.routeData.time.push(tm)
+          };
+        }
+      };
+      this.processGPSTrack();
+    },
 
     getStartOffset : function (timestring) {
       var secs;

--- a/js/rg2getjson.js
+++ b/js/rg2getjson.js
@@ -127,6 +127,9 @@
       rg2.courses.generateControlList(rg2.controls);
       $("#btn-toggle-controls").show();
       $("#btn-toggle-names").show();
+      if (json.data.strava ==='false'){
+        $("#btn-get-strava").hide();
+      }
       processResults(json);
       processGPSTracks(json);
       rg2.eventLoaded();

--- a/js/rg2ui.js
+++ b/js/rg2ui.js
@@ -145,6 +145,7 @@
       $("#btn-reset-drawing").button().button("disable").click(function () {
         rg2.drawing.resetDrawing();
       });
+      $("#btn-get-strava").button().button("disable");
       $("#btn-save-gps-route").button().button("disable").click(function () {
         rg2.drawing.saveGPSRoute();
       });
@@ -663,6 +664,34 @@
       $("#rg2-load-gps-file").change(function (evt) {
         rg2.drawing.uploadGPS(evt);
       });
+
+      $("#btn-get-strava").click(function(){
+        //open oauth popup. return list of latest activities.
+        rg2.utils.oauthpopup({
+        path: 'https://www.strava.com/oauth/authorize?client_id=65468&response_type=code&redirect_uri='+window.location.protocol+'//'+window.location.hostname+'/rg2/rg2api.php&approval_prompt=force&scope=activity:read_all',
+        callback: function(activities){
+  
+            //parse the returned json
+            var activ = JSON.parse(activities);
+            var act =  activ.activities;
+            var token = activ.access_token;
+            
+            //reset div to empty
+            document.getElementById('strava-activities').innerHTML = '';
+            //disable load button
+            $("#btn-get-strava").button("disable");
+ 
+            //add current activities to div so user can select one
+            //limit to 10
+            for (var i=0; i<10; i++){
+              var a = act[i];
+              var activityId = a.id.toString()
+              rg2.utils.addStravaActivitySelector('strava-activities', activityId, a.name, token, a.type, a.start_date_local);
+            }
+          }
+        });
+      });
+
     },
 
     configureUI: function () {

--- a/js/utils.js
+++ b/js/utils.js
@@ -2,6 +2,100 @@
 /*global rg2Config:false */
 (function () {
   var utils =  {
+
+    oauthpopup : function (options){
+      // Open another window for oauth authorisation. Pass token back to main window when successful.
+      options.windowName = options.windowName ||  'ConnectWithOAuth'; // should not include space for IE
+      options.windowOptions = options.windowOptions || 'location=0,status=0,width=800,height=400';
+      options.callback = options.callback || function(){ window.location.reload(); };
+      var that = this;
+      console.log(options.path);
+      that._oauthWindow = window.open(options.path, options.windowName, options.windowOptions);
+      that._oauthInterval = window.setInterval(function(){
+  
+      var activities = '';
+      
+      if (that._oauthWindow.document.body.innerHTML.startsWith('{"access_token":')){
+        activities = that._oauthWindow.document.body.innerHTML;
+        that._oauthWindow.close();
+      } 
+      
+      if (that._oauthWindow.closed) {
+              window.clearInterval(that._oauthInterval);
+              options.callback(activities);
+          }
+      }, 1000);
+    },
+
+    addStravaActivitySelector: function (elementId, activityId, name, token, type, dt){
+
+      //Reformat string as date
+      dat = dt.substring(0,10)+ " "+ dt.substring(11,16)
+
+      //create button elements
+      var border = document.createElement("div");
+      border.className= 'border';
+
+      var act = document.createElement("div");
+      act.className= 'grid-container';
+      
+      var actTitle = document.createElement("span");
+	    actTitle.setAttribute("id", "act-title");
+	    actTitle.innerText = name;
+	    act.appendChild(actTitle);
+
+      var actType = document.createElement("span");
+	    actType.setAttribute("id", "act-type");
+	    actType.innerText = type;
+	    act.appendChild(actType);
+
+      var actDate = document.createElement("span");
+	    actDate.setAttribute("id", "act-date");
+	    actDate.innerText = dat;
+	    act.appendChild(actDate);
+
+      var btn = document.createElement("span");
+	    btn.setAttribute("id", "act-btn");
+      btn.className = "act-btn";
+	    btn.innerText = 'Add';
+	    act.appendChild(btn);
+
+      //request activity stream onclick and load to interface.
+      btn.onclick = function() {
+        btn.innerText = "Added";
+
+        //disable other buttons
+        var cusid_ele = document.getElementsByClassName('act-btn');
+        for (var i = 0; i < cusid_ele.length; ++i) {
+          var item = cusid_ele[i];  
+          if (item.innerText === 'Add'){
+            //hide other buttons. Not strictly necessary as clicking different add will override
+            //but probably more obvious to the user if we don't allow it?
+            item.style.visibility = 'hidden';
+          } else {
+            //disable Added button
+            item.style.pointerEvents = 'none';
+          }
+        }
+
+        // get activity stream
+        $.getJSON(rg2Config.json_url, {
+          type : "stravaActivityStream",
+          id : activityId+'|'+token,
+          cache : false
+        }).done(function (json) {
+          rg2.drawing.uploadStrava(json);
+        }).fail(function (jqxhr, textStatus, error) {
+          /*jslint unparam:true*/
+          reportJSONFail("Activities request failed: " + error);
+        });
+      }
+      
+      border.appendChild(act);
+      document.getElementById(elementId).appendChild(border);
+      
+    },
+
     rotatePoint : function (x, y, angle) {
       // rotation matrix: see http://en.wikipedia.org/wiki/Rotation_matrix
       var pt = {};

--- a/rg2-config .txt
+++ b/rg2-config .txt
@@ -56,3 +56,7 @@
   // or 
   //define('EPSG_CODE', "EPSG:12345|EPSG:67890");
   //define('EPSG_PARAMS', "+proj=x +ellps=WGS84 +datum=WGS84 +units=m +no_defs|+proj=y +ellps=WGS84 +datum=WGS84 +units=m +no_defs");
+  
+  // If using strava, add the application oauth client and secret
+  //define('STRAVA_CLIENT', '')
+  //define('STRAVA_SECRET', '')


### PR DESCRIPTION
This pull request adds the functionality to allow an admin to configure rg2 to allow users to upload a recent activity directly from Strava and use them as route drawings. It makes it easier for users as they do not need to download the gpx file then reupload the file to rg2.

The configuration for admins is simple. Simply create a Strava API application and retrieve the application oAuth2 client and secret. Define STRAVA_CLIENT and STRAVA_SECRET in rg2-config.

If the oauth values are undefined, the user will not see the 'Get 10 most recent strava activities' button.

If defined, the user will see a button in the Draw tab which will allow them to sign in to strava via an oauth popup window, and the application will list their 10 most recent activities. They can then select one to add it to the map.

-------------

I did have to bodge the existing GET listener to accept the oauth code parameter. Can't see any way around this.
