### PR TITLE
Reorder animation toolbar

### DIFF
--- a/css/rg2.css
+++ b/css/rg2.css
@@ -66,7 +66,7 @@ html, body {
     position: absolute;
     vertical-align: middle;
     height: 36px;
-	  width: 280px;
+	  width: 380px;
     right: 0;
 	  border: 4px solid darkgray;
   	z-index: 100;
@@ -74,20 +74,15 @@ html, body {
 }
 
 .row-1 {
-    bottom: 120px;
+    bottom: 80px;
     font-size: 20px;
 }
 
 .row-2 {
-    bottom: 80px;
+    bottom: 40px;
 }
 
 .row-3 {
-    bottom: 40px;
-    color: black;
-}
-
-.row-4 {
     bottom: 0;
     color: black;
 }
@@ -110,18 +105,31 @@ html, body {
 	float: right;
 	width: 30px;
 	text-align: center;
-	border-left: 4px solid darkgray;
+	border-right: 4px solid darkgray;
+}
+
+.rg2-button-left {
+  background: silver;
+  color: white;
+	float: left;
+	width: 30px;
+	text-align: center;
+	border-right: 4px solid darkgray;
 }
 
 .rg2-wide-button {
   background: silver;
   color: white;
-	float: right;
-	width: 64px;
+	float: left;
+	width: 55px;
 	text-align: center;
-	border-left: 4px solid darkgray;
+  border-right: 4px solid darkgray;
 }
-.rg2-button:hover {
+.rg2-button:hover  {
+  color: darkgray;
+}
+
+.rg2-button-left:hover{
   color: darkgray;
 }
 
@@ -216,12 +224,15 @@ html, body {
    font-size: 26px;
    color: black;
  	 text-align: center;
+    float:left;
+    margin-left: 20px;
 }
 
 #rg2-tails-type {
 	padding-left: 5px;
 	border-right: 4px solid darkgray;
-	width: 100px;
+	width: 93px;
+  float:left;
 }
 
 #spn-tail-length {
@@ -231,6 +242,7 @@ html, body {
 #rg2-tails-spinner {
   float: right;
   padding-right: 5px;
+  border-right: 4px solid darkgray;
 }
 
 .rg2-spinner {
@@ -386,8 +398,9 @@ html, body {
 }
 
 #rg2-replay-start-control {
-  float: left;
+  float: right;
   padding-left: 5px;
+  margin-right:5px
 }
 
 .pushright {
@@ -482,8 +495,10 @@ padding: 0;
 }
 
 #rg2-clock-slider {
-  margin: 10px 15px;
+  margin: 10px 25px;
   width: 180px;
+  float:right;
+
 }
 
 #rg2-clock-slider .ui-state-default {

--- a/html/animation.html
+++ b/html/animation.html
@@ -1,30 +1,28 @@
   <div id="rg2-animation-controls">
     <div class="rg2-ani-row row-1">
-      <div class="rg2-button"><i id="btn-slower" title = "Slower" class="fa fa-minus"></i></div>
-      <div class="rg2-button"><i id="btn-faster" title = "Faster" class="fa fa-plus"></i></div>
-      <div class="rg2-button"><i id="btn-real-time" title = "Real time" class="fa fa-users"></i></div>
-      <div class="rg2-button"><i id="btn-start-stop" title = "Run" class="fa fa-play"></i></div>
       <div id="rg2-clock"></div>
-    </div>
-    <div class="rg2-ani-row row-2">
-      <div id="rg2-animation-speed" class="rg2-wide-button"></div>
       <div id="rg2-clock-slider"></div>
     </div>
-    <div class="rg2-ani-row row-3">
+    <div class="rg2-ani-row row-2">
+      <div class="rg2-button-left"><i id="btn-real-time" title = "Mass start mode | View real-time mode" class="fa fa-users"></i></div>
+      <div class="rg2-button-left"><i id="btn-start-stop" title = "Run" class="fa fa-play"></i></div>
+      <div class="rg2-button-left"><i id="btn-slower" title = "Slower" class="fa fa-backward"></i></div>
+      <div id="rg2-animation-speed" class="rg2-wide-button"></div>
+      <div class="rg2-button-left"><i id="btn-faster" title = "Faster" class="fa fa-forward"></i></div>
       <div id="rg2-replay-start-control">
         <label for="rg2-control-select">Start at</label>
         <select  id="rg2-control-select"><option>S</option></select>
       </div>
+    </div>
+    <div class="rg2-ani-row row-3">
       <div class="rg2-button"><i id="btn-show-splits" title = "Splits" class="fa fa-list-alt"></i></div>
       <div class="rg2-button"><i id="btn-toggle-names" title = "Show initials" class="fa fa-tag"></i></div>
-    </div>
-    <div class="rg2-ani-row row-4">
       <div id="rg2-tails-spinner">
-        <label for="spn-tail-length">Length</label>
+        <label for="spn-tail-length">or length (mins)</label>
         <input id="spn-tail-length" name="value" />
       </div>
       <div id="rg2-tails-type">
-        <label for="btn-full-tails">Full tails</label>
+        <label for="btn-full-tails">Full tails?</label>
         <input type="checkbox" id="btn-full-tails" />
       </div>
     </div>

--- a/js/animation.js
+++ b/js/animation.js
@@ -43,7 +43,7 @@
       this.displayInitials = false;
       this.updateAnimationDetails();
       $("#btn-start-stop").removeClass('fa-pause').addClass('fa-play').prop('title', rg2.t('Run'));
-      $("#btn-real-time").removeClass().addClass('fa fa-users').prop('title', rg2.t('Real time'));
+      $("#btn-real-time").removeClass().addClass('fa fa-users').prop('title', rg2.t('Mass start mode | View real-time mode'));
       $("#btn-toggle-names").prop('title', rg2.t('Show initials'));
     },
 
@@ -333,13 +333,13 @@
       // toggles between mass start and real time
       if (this.realTime) {
         this.realTime = false;
-        $("#btn-real-time").removeClass().addClass('fa fa-users').prop('title', rg2.t('Real time'));
+        $("#btn-real-time").removeClass().addClass('fa fa-users').prop('title', rg2.t('Mass start mode | View real-time mode'));
         if (rg2.courses.getHighestControlNumber() > 0) {
           $("#rg2-control-select").prop('disabled', false);
         }
       } else {
         this.realTime = true;
-        $("#btn-real-time").removeClass().addClass('fa fa-clock').prop('title', rg2.t('Mass start'));
+        $("#btn-real-time").removeClass().addClass('fa fa-clock').prop('title', rg2.t('Real-time mode | View mass start mode'));
         $("#rg2-control-select").prop('disabled', true);
       }
       // go back to start


### PR DESCRIPTION
Suggestion to reorder the animation toolbar to make it a bit easier for newbies to follow. 

Especially keen to replace the animation speed buttons - at the moment it looks more like map zoom buttons.

![image](https://user-images.githubusercontent.com/8209810/125753571-951b431a-a1b4-4a32-9b0d-467e17fbc668.png)
