### PR TITLE
Add ability to update results without affecting existing routes

### DIFF
--- a/app/event.php
+++ b/app/event.php
@@ -412,6 +412,14 @@ class event
             file_put_contents(KARTAT_DIRECTORY."kilpailijat_".$newid.".txt", $result, FILE_APPEND);
         }
 
+        // create new mappings file: result to class
+        $classmappings = "";
+        for ($i = 1; $i < count($data->mappings); $i++) {
+            $classmappings .= utils::encode_rg_output($data->mappings[$i]->class)."|".utils::encode_rg_output($data->mappings[$i]->course)."|".$i.PHP_EOL;
+        }
+        file_put_contents(KARTAT_DIRECTORY."mappings_".$newid.".txt", $classmappings, FILE_APPEND);
+
+
         if ($write["status_msg"] == "") {
             $write["ok"] = true;
             $write["status_msg"] = "Event created.";

--- a/app/event.php
+++ b/app/event.php
@@ -413,12 +413,10 @@ class event
         }
 
         // create new mappings file: result to class
-        $classmappings = "";
         for ($i = 1; $i < count($data->mappings); $i++) {
-            $classmappings .= utils::encode_rg_output($data->mappings[$i]->class)."|".utils::encode_rg_output($data->mappings[$i]->course)."|".$i.PHP_EOL;
+            $classmappings = utils::encode_rg_output($data->mappings[$i]->class)."|".utils::encode_rg_output($data->mappings[$i]->course)."|".$i.PHP_EOL;
+            file_put_contents(KARTAT_DIRECTORY."mappings_".$newid.".txt", $classmappings, FILE_APPEND);
         }
-        file_put_contents(KARTAT_DIRECTORY."mappings_".$newid.".txt", $classmappings, FILE_APPEND);
-
 
         if ($write["status_msg"] == "") {
             $write["ok"] = true;

--- a/app/event.php
+++ b/app/event.php
@@ -412,10 +412,15 @@ class event
             file_put_contents(KARTAT_DIRECTORY."kilpailijat_".$newid.".txt", $result, FILE_APPEND);
         }
 
-        // create new mappings file: result to class
+        // create new mappings file: result classname|coursename|courseid so we can match them up again for updates. 
+        // may be able to use the sarjat file but don't want to touch it - I don't know what it could break in RG1
         for ($i = 1; $i < count($data->mappings); $i++) {
-            $classmappings = utils::encode_rg_output($data->mappings[$i]->class)."|".utils::encode_rg_output($data->mappings[$i]->course)."|".$i.PHP_EOL;
-            file_put_contents(KARTAT_DIRECTORY."mappings_".$newid.".txt", $classmappings, FILE_APPEND);
+            $class = utils::encode_rg_output($data->mappings[$i]->class);
+            $course = utils::encode_rg_output($data->mappings[$i]->course);
+            $courseid = utils::encode_rg_output($data->mappings[$i]->courseid);
+
+            $classmapping = $class."|".$course."|".$courseid.PHP_EOL;
+            file_put_contents(KARTAT_DIRECTORY."mappings_".$newid.".txt", $classmapping, FILE_APPEND);
         }
 
         if ($write["status_msg"] == "") {
@@ -447,7 +452,7 @@ class event
 
         // rename all associated files but don't worry about errors
         // safer than deleting them since you can always add the event again
-        $files = array("kilpailijat_", "kommentit_", "hajontakanta_", "merkinnat_", "radat_", "ratapisteet_", "sarjat_", "sarjojenkoodit_");
+        $files = array("kilpailijat_", "kommentit_", "hajontakanta_", "merkinnat_", "radat_", "ratapisteet_", "sarjat_", "sarjojenkoodit_", "mappings_");
         foreach ($files as $file) {
             @rename(KARTAT_DIRECTORY.$file.$eventid.".txt", KARTAT_DIRECTORY."deleted_".$file.$eventid.".txt");
         }

--- a/app/result.php
+++ b/app/result.php
@@ -295,7 +295,7 @@ class result
 								
 							$row = array();
 							$row["origresultid"] = $old[0];
-							$row["newresultid"] = 100000 + $kil["newresultid"];
+							$row["newresultid"] = GPS_RESULT_OFFSET + $kil["newresultid"];
 							$row["origcourseid"] = $old[1];
 							$row["newcourseid"] = $kil["newcourseid"];
 							$row["coursename"] = $old[2];

--- a/app/result.php
+++ b/app/result.php
@@ -303,8 +303,7 @@ class result
                         $kilpailijat[] = $row;
 
                         $result = $row["newresultid"]."|".$row["newcourseid"]."|".$row["coursename"];
-                        $result .= "|".$row["name"]."|".$old[4]."|||".$old[7]."||".$old[9].PHP_EOL;
-                        // doesn't save all params - see  "abusing dbid to save status and position" comment above
+                        $result .= "|".$row["name"]."|".$old[4]."|".$old[5]."|".$old[6]."|".$old[7]."|".$old[8]."|".$old[9];
 
                         file_put_contents(KARTAT_DIRECTORY."kilpailijat_".$eventid.".txt", $result, FILE_APPEND);
 
@@ -330,7 +329,7 @@ class result
                 foreach ($kilpailijat as $k){
                     if ($k["origresultid"] == $olddata[1]){
 
-                        $row = $k["newcourseid"]."|".$k["newresultid"]."|".$olddata[2]."||".$olddata[4];
+                        $row = $k["newcourseid"]."|".$k["newresultid"]."|".$olddata[2]."|".$olddata[3]."|".$olddata[4];
 
                         $updatedfile[] = $row;
 
@@ -364,7 +363,7 @@ class result
                     foreach ($kilpailijat as $k){
                         if ($k["origresultid"] == $olddata[1]){
 
-                            $row = $k["newcourseid"]."|".$k["newresultid"]."|".$olddata[2]."|null|".$olddata[4];
+                            $row = $k["newcourseid"]."|".$k["newresultid"]."|".$olddata[2]."|".$olddata[2]."|".$olddata[4];
 
                             $updatedfile[] = $row;
 

--- a/html/manager.html
+++ b/html/manager.html
@@ -55,7 +55,7 @@
     <span>Move map and controls together <input type="checkbox" id="btn-move-map-and-controls"></span>
   </div>
   <div id="rg2-course-allocations"></div>
-  <button type="button" id="btn-add-fieldmapping">Add mapping</button>
+  <button type="button" id="btn-add-fieldmapping">Add class-course pair</button>
   <hr class="rg2-hr">
   <div>
     <span>Read-only (enable drawing via "Edit event" tab) <input type="checkbox" id="chk-read-only"></span>

--- a/html/manager.html
+++ b/html/manager.html
@@ -55,6 +55,7 @@
     <span>Move map and controls together <input type="checkbox" id="btn-move-map-and-controls"></span>
   </div>
   <div id="rg2-course-allocations"></div>
+  <button type="button" id="btn-add-fieldmapping">Add mapping</button>
   <hr class="rg2-hr">
   <div>
     <span>Read-only (enable drawing via "Edit event" tab) <input type="checkbox" id="chk-read-only"></span>
@@ -94,6 +95,12 @@
       <select id="rg2-route-selected"></select>
       <br/>
       <button type="button" class="manage-file-label" id="btn-delete-route">Delete</button>
+    </div>
+    <div>
+        <hr class="rg2-hr">
+        <h3 class="no-top-margin">Update results</h3>
+        <span>Results file<input type='file' accept='.csv, .xml' id='rg2-update-results-file' class="pushright manage-file-input" /></span>
+        <button type="button" class="manage-file-label" id="btn-update-results">Update results</button>
     </div>
     <hr class="rg2-hr">
     <h3 class="no-top-margin">Delete event</h3>

--- a/js/manager.js
+++ b/js/manager.js
@@ -372,8 +372,6 @@
           var html2 = "<tr><td><input type=\"text\"/></td><td>" + this.createCourseDropdown("New Class", 1) + "</td></tr>";
           var html = html1 + html2 + tableEnd
 
-          console.log(html)
-
           $("#rg2-course-allocations").empty().append(html);
       },
 
@@ -516,30 +514,40 @@
         delete data.results[i].chipid;
         delete data.results[i].club;
       }
-      data.mappings = this.generateFieldMappings();
+      data.mappings = this.generateFieldMappings(data.courses);
       user = this.user.encodeUser();
       data.x = user.x;
       data.y = user.y;
       return JSON.stringify(data);
     },
 
-      generateFieldMappings: function () {
-          data = [];
-          $('#rg2-course-allocations tr').each(function (i, row) {
-              var $row = $(row);
-              $class = $row.find('td:first').text();
+    generateFieldMappings: function (courses) {
+      console.log(courses);
+        data = [];
+        $('#rg2-course-allocations tr').each(function (i, row) {
+            var $row = $(row);
+            $class = $row.find('td:first').text();
 
-              //could be manual input - try input instead
-              if ($class.length == 0){
-                $class = $row.find('input').val();
+            //could be manual input - try input instead
+            if ($class.length == 0){
+              $class = $row.find('input').val();
+            }
+            $course = $row.find(':selected').text();
+
+            $courseid = 0
+            //Get courseids
+            for (var i = 0; i<courses.length; i++){
+              if (courses[i].name == $course){
+                $courseid = courses[i].courseid;
               }
-              $course = $row.find(':selected').text();
-              data.push({
-                  "class": $class, "course": $course })
-          })
+            }
 
-          return data;
-      },
+            data.push({
+                "class": $class, "course": $course, "courseid":$courseid })
+        })
+
+        return data;
+    },
 
 
     hasZeroTime: function (time) {
@@ -1574,7 +1582,7 @@
         // save new cookie
         self.user.y = data.keksi;
         if (data.ok) {
-          rg2.utils.showWarningDialog("Results updated.", "Results for " + self.eventName + " have been updated.");
+          rg2.utils.showWarningDialog("Results updated.", "Results have been updated.");
           // open newly created event in a separate window
           window.open(rg2Config.json_url.replace("rg2api.php", "") + "#" + data.newid);
           rg2.getEvents();

--- a/js/manager.js
+++ b/js/manager.js
@@ -168,7 +168,7 @@
       });
       $("#rg2-load-course-file").button().click(function (evt) {
         if (!self.mapLoaded) {
-          rg2.utils.showWarningDialog("No event loaded", "Please load a map file before adding courses.");
+          rg2.utils.showWarningDialog("No map loaded", "Please load a map file before adding courses.");
           evt.preventDefault();
         }
       }).change(function (evt) {
@@ -180,7 +180,7 @@
 
       $("#rg2-update-results-file").button().click(function (evt) {
         if (!self.mapLoaded) {
-          rg2.utils.showWarningDialog("No event loaded", "Please load an event before adding results.");
+          rg2.utils.showWarningDialog("No event loaded", "Please select an event before adding results.");
           evt.preventDefault();
         }
       }).change(function (evt) {

--- a/js/manager.js
+++ b/js/manager.js
@@ -122,6 +122,9 @@
       $("#btn-update-event").button().click(function () {
         self.confirmUpdateEvent();
       }).button("disable");
+      $("#btn-update-results").button().click(function () {
+        self.confirmUpdateResults();
+      }).button("disable");
       $("#btn-delete-route").button().click(function () {
         self.confirmDeleteRoute();
       }).button("disable");
@@ -151,9 +154,6 @@
         self.initialiseEncodings();
         self.readResults();
       });
-      $("#btn-update-results").button().click(function () {
-        self.confirmUpdateResults();
-      });
       $("#btn-move-map-and-controls").click(function (evt) {
         self.toggleMoveAll(evt.target.checked);
       });
@@ -168,7 +168,7 @@
       });
       $("#rg2-load-course-file").button().click(function (evt) {
         if (!self.mapLoaded) {
-          rg2.utils.showWarningDialog("No map loaded", "Please load a map file before adding courses.");
+          rg2.utils.showWarningDialog("No event loaded", "Please load a map file before adding courses.");
           evt.preventDefault();
         }
       }).change(function (evt) {
@@ -180,7 +180,7 @@
 
       $("#rg2-update-results-file").button().click(function (evt) {
         if (!self.mapLoaded) {
-          rg2.utils.showWarningDialog("No map loaded", "Please load a map file before adding results.");
+          rg2.utils.showWarningDialog("No event loaded", "Please load an event before adding results.");
           evt.preventDefault();
         }
       }).change(function (evt) {
@@ -516,6 +516,7 @@
         delete data.results[i].chipid;
         delete data.results[i].club;
       }
+      data.mappings = this.generateFieldMappings();
       user = this.user.encodeUser();
       data.x = user.x;
       data.y = user.y;
@@ -526,7 +527,12 @@
           data = [];
           $('#rg2-course-allocations tr').each(function (i, row) {
               var $row = $(row);
-              $class = $row.find('input').val();
+              $class = $row.find('td:first').text();
+
+              //could be manual input - try input instead
+              if ($class.length == 0){
+                $class = $row.find('input').val();
+              }
               $course = $row.find(':selected').text();
               data.push({
                   "class": $class, "course": $course })
@@ -1568,7 +1574,7 @@
         // save new cookie
         self.user.y = data.keksi;
         if (data.ok) {
-          rg2.utils.showWarningDialog("Results updated");
+          rg2.utils.showWarningDialog("Results updated.", "Results for " + self.eventName + " have been updated.");
           // open newly created event in a separate window
           window.open(rg2Config.json_url.replace("rg2api.php", "") + "#" + data.newid);
           rg2.getEvents();

--- a/js/manager.js
+++ b/js/manager.js
@@ -151,6 +151,9 @@
         self.initialiseEncodings();
         self.readResults();
       });
+      $("#btn-update-results").button().click(function () {
+        self.confirmUpdateResults();
+      });
       $("#btn-move-map-and-controls").click(function (evt) {
         self.toggleMoveAll(evt.target.checked);
       });
@@ -171,6 +174,21 @@
       }).change(function (evt) {
         self.readCourses(evt);
       });
+        $("#btn-add-fieldmapping").button().click(function () {
+            self.addFieldMapping();
+        });
+
+      $("#rg2-update-results-file").button().click(function (evt) {
+        if (!self.mapLoaded) {
+          rg2.utils.showWarningDialog("No map loaded", "Please load a map file before adding results.");
+          evt.preventDefault();
+        }
+      }).change(function (evt) {
+        self.resultsOrCourseFile = evt.target.files[0];
+        self.initialiseEncodings();
+        self.readResults();
+      });
+
     },
 
     validateMapUpload: function (upload) {
@@ -345,6 +363,20 @@
       }
     },
 
+      addFieldMapping: function () {
+
+          var tableEnd = "</tbody></table></div>";
+
+          var html1 = $("#rg2-course-allocations").html().replace(tableEnd, "");
+
+          var html2 = "<tr><td><input type=\"text\"/></td><td>" + this.createCourseDropdown("New Class", 1) + "</td></tr>";
+          var html = html1 + html2 + tableEnd
+
+          console.log(html)
+
+          $("#rg2-course-allocations").empty().append(html);
+      },
+
     validateData: function () {
       if (!this.eventName) {
         return 'Event name is not valid.';
@@ -489,6 +521,20 @@
       data.y = user.y;
       return JSON.stringify(data);
     },
+
+      generateFieldMappings: function () {
+          data = [];
+          $('#rg2-course-allocations tr').each(function (i, row) {
+              var $row = $(row);
+              $class = $row.find('input').val();
+              $course = $row.find(':selected').text();
+              data.push({
+                  "class": $class, "course": $course })
+          })
+
+          return data;
+      },
+
 
     hasZeroTime: function (time) {
       if (time === 0 || time === '0' || time === '0:00' || time === '00:00') {
@@ -1502,7 +1548,65 @@
       $("#rg2-world-file-map").show();
       this.georefmap.invalidateSize();
       this.georefmap.fitBounds(poly.getBounds());
-    }
+  },
+
+  confirmUpdateResults : function () {
+    var self, data, id;
+    $("#event-create-dialog").dialog("destroy");
+    self = this;
+    data = this.generateUpdatedResults();
+    $("#rg2-load-progress-label").text("Creating event");
+      $("#rg2-load-progress").show();
+      id = $("#rg2-event-selected").val();
+    console.log(data)
+      $.ajax({
+          data: data,
+          type : "POST",
+          url: rg2Config.json_url + "?type=updateresults&id=" + id,
+      dataType : "json",
+      success : function (data) {
+        // save new cookie
+        self.user.y = data.keksi;
+        if (data.ok) {
+          rg2.utils.showWarningDialog("Results updated");
+          // open newly created event in a separate window
+          window.open(rg2Config.json_url.replace("rg2api.php", "") + "#" + data.newid);
+          rg2.getEvents();
+          rg2.managerUI.setEvent();
+        } else {
+          rg2.utils.showWarningDialog("Save failed", data.status_msg + " Failed to update results. Please try again.");
+        }
+      },
+      error : function () {
+        rg2.utils.showWarningDialog("Save failed", " Failed to update results.");
+      },
+      complete : function () {
+        $("#rg2-load-progress-label").text("");
+        $("#rg2-load-progress").hide();
+      }
+     });
+    },
+
+    generateUpdatedResults : function () {
+
+      var data, user;
+        data = {};
+        data.results = this.results.slice(0);
+
+        for (i = 0; i < data.results.length; i += 1) {
+            data.results[i].variantid=0
+        }
+
+
+      user = this.user.encodeUser();
+      data.x = user.x;
+      data.y = user.y;
+      
+      return JSON.stringify(data);
+
+    },
+
+
   };
   rg2.Manager = Manager;
 }());

--- a/js/managerui.js
+++ b/js/managerui.js
@@ -137,7 +137,7 @@
       $("#rg2-event-level-edit").val(event.rawtype);
       $("#rg2-edit-event-comments").empty().val(rg2.he.decode(event.comment));
       $("#chk-edit-read-only").prop("checked", event.locked);
-      rg2.utils.setButtonState("enable", ["#btn-delete-event", "#btn-update-event", "#btn-delete-route"]);
+      rg2.utils.setButtonState("enable", ["#btn-delete-event", "#btn-update-event", "#btn-delete-route", "#btn-update-results"]);
       this.createRouteDeleteDropdown(event.id);
     },
 

--- a/rg2api.php
+++ b/rg2api.php
@@ -112,6 +112,13 @@ function handlePostRequest($type, $eventid)
         @unlink(CACHE_DIRECTORY."stats.json");
        break;
 
+      case 'updateresults':
+          // this a modified editevent function
+        $write = result::updateResults($eventid, $data);
+        @unlink(CACHE_DIRECTORY."events.json");
+        @unlink(CACHE_DIRECTORY."stats.json");
+        break;
+
       case 'deleteroute':
           // this is the manager delete function
         $write = route::deleteRoute($eventid);


### PR DESCRIPTION
This functionality will make it possible to have rg2 available at events (not just afterwards). 

As competitors finish, admins will be able to upload updated xml files, and routes that have already been uploaded will be renumbered so that they are against the correct competitor. The recently-finished competitors will be able to upload their routes once the xml update has been done. 

Alongside [pull request 487](https://github.com/Maprunner/rg2/pull/487), uploading routes should be simple on georeferenced maps.

This is the first step - ideally it would be possible to automate this process, however because a lot of parsing is done by the client before it is sent to the server, I've focused on getting it working from the client side first. 

You may want to initially call this a 'beta' feature as I have only tested it on relatively 'normal' events.

How it works:

- The user adds an intial course and results file. 
- The user lists all of the possible permutations of class to course.
- These class to course mappings are added to the json payload when an event is created and saved in a new file (mappings_.txt)
- When the event update is requested, the server checks the mappings file to see which courseid to map each result to ("Do not save" will remain ignored)
- The server then updates the kilpailijat, kommentit and merkinnat files, adding new runners with correct courseid and updating the positions of previously-added runners.