### PR TITLE
Fix deprecated self:: $callable() pattern

### DIFF
--- a/app/event.php
+++ b/app/event.php
@@ -177,7 +177,7 @@ class event
       }
       fclose($handle);
     }
-    usort($output, "self::sortEventsByDate");
+    usort($output, self::class . "::sortEventsByDate");
     return utils::addVersion("events", $output);
   }
 

--- a/app/map.php
+++ b/app/map.php
@@ -286,7 +286,7 @@ class map
       $write["status_msg"] = "";
       // extract list of GIF files
       $files = scandir(KARTAT_DIRECTORY);
-      $gifs = array_filter($files, "self::isGIF");
+      $gifs = array_filter($files, self::class . "::isGIF");
       $deleted = "";
       foreach ($gifs as $filename) {
         // replace gif with jpg in file name

--- a/app/result.php
+++ b/app/result.php
@@ -140,7 +140,7 @@ class result
           // event with no results so need to sort times and add positions
           // a lot easier to do this here in one place rather than when adding and deleting results
           // avoids multiple rewrites of full results file plus need to manage route deletion
-          usort($output, "self::sortResultsByCourseThenTime");
+          usort($output, self::class . "::sortResultsByCourseThenTime");
           $pos = 0;
           $ties = 0;
           $oldsecs = -1;


### PR DESCRIPTION
As of PHP 8.2, the "self::" callable convention is deprecated: https://php.watch/versions/8.2/partially-supported-callable-deprecation

From the article:

>The easiest way to avoid this deprecation notice is to make use of ::class magic constant that resolves to the actual class name. This should work all PHP >= 5.3 versions.

I have not tested this change on versions other than 8.3.3, and I am not sure what versions of PHP rg2 officially supports, but the app is broken on >= 8.2 due to this issue.

I haven't changed the code in the `dist/` folder - not sure if this needs to be done too?